### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
 
             <div id="sidebar">
                 <section id="docs">
-                    <h3><a href="http://django-tastypie.readthedocs.org/en/latest/index.html">Documentation</a></h3>
+                    <h3><a href="https://django-tastypie.readthedocs.io/en/latest/">Documentation</a></h3>
 
                     <p>
                         <strong>Current version:</strong>


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.